### PR TITLE
fix relative paths for deployment

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: '3.8'
       - name: Install and Build
         run: |
-          pip install -r requirements.txt && pelican content
+          pip install -r requirements.txt && SITE_PREFIX=/website pelican content -s publishconf.py
           
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/content/pages/de/about.rst
+++ b/content/pages/de/about.rst
@@ -16,7 +16,7 @@ Beruflich
 ---------
 .. container:: float-left
 
-    .. image:: /images/about/about.jpeg
+    .. image:: {attach}/images/about/about.jpeg
         :width: 150px
 
 Wie Sie sicher sehen können mag ich Wallace und Gromit. Ich bin Software Entwickler und System Administrator und Python ist meine Lieblingssprache. Ich kann HTML/CSS/JS aber es ist definitiv nicht meine Lieblingsbeschäftigung. PHP Code schreibe ich auch. Und auch wenn ich PHP nicht besonders gerne mag, ist es dennoch eine nützliche Sprache. Aktuell versuche ich mich etwas in GoLang (ich vermisse aber Exceptions) und ich hasse Ruby und Perl. Dafür gefällt mir NodeJS auch.
@@ -30,7 +30,7 @@ Freizeit
 --------
 .. container:: float-right
 
-    .. image:: /images/about/hiking.jpg
+    .. image:: {attach}/images/about/hiking.jpg
         :width: 250px
 
 In meiner Freizeit war ich früher gerne und oft Klettern. Heute bin ich aber hauptsächlich stolzer Vater eines grossartigen Mädchens. Ausserdem habe ich in den letzten Jahren leicht (sehr viel) zugenommen weshalb ich vermutlich so oder so nicht mehr so viel Klettern würde. Dennoch sind wir sehr gerne in den Bergen unterwegs, beim Wandern, Skifahren oder einfach beim Entspannen. Ausserdem liebe ich das Segeln in starkem (zumindest aus meiner Sicht, für Andere ist das vielleicht nur eine Brise) Wind. Ich liebe es in meiner kleinen Byte CII nass zu werden und dem Wind zu trotzen. Meine Segeleinheiten dauern meistens so 2 bis 3 Stunden was in etwa 400 Rumpfbeugen entspricht ;-)

--- a/content/pages/de/meetups.rst
+++ b/content/pages/de/meetups.rst
@@ -10,7 +10,7 @@ Meetups
 
 .. container:: float-left
 
-    .. image:: /images/meetups/tdd.jpg
+    .. image:: {attach}/images/meetups/tdd.jpg
         :width: 400px
 
 Meetups

--- a/content/pages/en/about.rst
+++ b/content/pages/en/about.rst
@@ -16,7 +16,7 @@ Profession
 ----------
 .. container:: float-left
 
-    .. image:: /images/about/about.jpeg
+    .. image:: {attach}/images/about/about.jpeg
         :width: 150px
 
 Well, as you can see I like wallace and gromit. I work as a software developer/system engineer and like python most. I am able to write html/css/js but it's defenitely not my favorite. Then I am also able to write php code. Ehm, even if I don't like it very much, it's still usefull here and there. Trying to get warm with golang (dislike absence of exceptions) and hater of ruby/perl. NodeJS is cool as well.

--- a/content/pages/en/meetups.rst
+++ b/content/pages/en/meetups.rst
@@ -10,7 +10,7 @@ Meetups
 
 .. container:: float-left
 
-    .. image:: /images/meetups/tdd.jpg
+    .. image:: {attach}/images/meetups/tdd.jpg
         :width: 400px
 
 Meetups

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -38,13 +38,18 @@ I18N_SUBSITES = {
   }
 }
 
+PREFIX_URL = os.getenv('SITE_PREFIX', '')
+
+def theme_image(url):
+  return PREFIX_URL + url
+
 # logo path, needs to be stored in PATH Setting
-LOGO = '/images/logo.png'
+LOGO = theme_image('/images/logo.png')
 
 # special content
 HERO = [
   {
-    'image': '/images/hero/background-1.jpg',
+    'image': theme_image('/images/hero/background-1.jpg'),
     # for multilanguage support, create a simple dict
     'title': {
       'en':'PyLadies Berlin on YouTube',
@@ -62,7 +67,7 @@ HERO = [
       }
     ]
   }, {
-    'image': '/images/hero/background-2.jpg',
+    'image': theme_image('/images/hero/background-2.jpg'),
     # keep it a string if you dont need multiple languages
     'title': 'This is PyLadies Berlin',
     'text': {
@@ -78,7 +83,7 @@ HERO = [
     }, 
     
     {
-    'image': '/images/hero/background-3.jpg',
+    'image': theme_image('/images/hero/background-3.jpg'),
     'title': 'Meetups',
     'text': {
       'en': 'Meet the PyLadies community, learn something new about Python and become an active member.',
@@ -91,7 +96,7 @@ HERO = [
       }
     ]
   }, {
-    'image': '/images/hero/background-4.jpg',
+    'image': theme_image('/images/hero/background-4.jpg'),
     'title': 'Python learning resources',
     'text': {
       'eng': 'Find a list of amazing resources for your Python learning journey.',
@@ -114,7 +119,7 @@ SOCIAL = (
 )
 
 ABOUT = {
-  'image': '/images/about/about.jpeg',
+  'image': theme_image('/images/about/about.jpeg'),
   'mail': 'berlin@pyladies.com',
   # keep it a string if you dont need multiple languages
   'text': {
@@ -126,7 +131,7 @@ ABOUT = {
   'address': 'Berlin, Germany',
   #'email': 'berlin@pyladies.com'
   'slack': {
-    'image': '/images/about/slack-logo.png',
+    'image': theme_image('/images/about/slack-logo.png'),
     'link': 'https://slackin.pyladies.com/',
     'text': 'Join us on slack in #city-berlin channel!'
   }

--- a/publishconf.py
+++ b/publishconf.py
@@ -10,7 +10,7 @@ import sys
 sys.path.append(os.curdir)
 from pelicanconf import *
 
-SITEURL = 'https://pyladiesberlin.github.io/website/'
+SITEURL = 'https://pyladiesberlin.github.io/website'
 RELATIVE_URLS = False
 
 FEED_ALL_ATOM = 'feeds/all.atom.xml'


### PR DESCRIPTION
  Since we deploy in /website to have the paths working in both cases (/website deployment) and locally we need:
     
-  use  `{attach}` in rst articles that will append the correct path - Pelican feature
-  use the `theme_image` hack for urls used directly from the theme (the {attach} didn't work there)
-  deploy with SITE with `PREFIX` env var to adjust the theme_image hack for the deployed version