### PR TITLE
don't quote template {social.url}

### DIFF
--- a/src/components/home/Hero.astro
+++ b/src/components/home/Hero.astro
@@ -59,7 +59,7 @@ const socials = [
               type="button"
               class="text-primary-950 dark:text-primary-200 hover:bg-primary-500/10 dark:hover:bg-primary-400/10 ring-primary-950 h-14 w-14 items-center justify-center rounded-full transition focus:outline-none focus-visible:ring-2 hidden sm:inline-flex"
             >
-            <a href="{social.url}">
+            <a href={social.url}>
               <svg
                 x-cloak
                 class="h-6 w-6"


### PR DESCRIPTION
`"{social.url}"` shows up verbatim in the html and results in broken links at the top of the page to the social networks